### PR TITLE
fix: package dependencies for dirmaker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+jinja2
+PyYAML
+

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,15 @@ from setuptools import setup
 
 README = open("README.md").read()
 
+def requirements():
+    with open('requirements.txt') as f:
+        return f.read().splitlines()
+
+
+
 setup(
     name="dirmaker",
-    version="0.1.0",
+    version="0.1.1",
     description="A simple static site generator for generating directory websites.",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -14,6 +20,7 @@ setup(
     author_email="kailash@nadh.in",
     url="https://github.com/knadh/dirmaker",
     packages=['dirmaker'],
+    install_requires=requirements(),
     include_package_data=True,
     download_url="https://github.com/knadh/dirmaker",
     license="MIT License",
@@ -27,5 +34,4 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: Site Management",
         "Topic :: Documentation"
     ],
-    install_required=["jinja2"],
 )


### PR DESCRIPTION
- Adds `requirements.txt` for external dependencies required
by `dirmaker`.
- Modifies `setup.py` to read the list of dependencies from the
above file.
- Bumps version to 0.1.1