### PR TITLE
fix: markupsafe version dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jinja2==2.11.3
 PyYAML==5.4.1
+markupsafe==2.0.1


### PR DESCRIPTION
Added `markupsafe` version dependency since `soft_unicode` was removed in the later version that broke jinja2. (Ref: https://github.com/pallets/jinja/issues/1585)  

This fixes the import error: `ImportError: cannot import name 'soft_unicode' from 'markupsafe' ` when running `dirmaker --build` 
